### PR TITLE
fix: set backtest columns to float to avoid pandas dtype warning

### DIFF
--- a/multi_stock_analysis.py
+++ b/multi_stock_analysis.py
@@ -133,9 +133,9 @@ def generate_signals(df):
 # 回测策略
 def backtest(df, initial_capital=100000):
     df['Position'] = 0
-    df['Cash'] = initial_capital
-    df['Holdings'] = 0
-    df['Portfolio'] = initial_capital
+    df['Cash'] = float(initial_capital)
+    df['Holdings'] = 0.0
+    df['Portfolio'] = float(initial_capital)
     
     position = 0
     cash = initial_capital

--- a/quant_trading.py
+++ b/quant_trading.py
@@ -124,9 +124,9 @@ def generate_signals(df):
 # 回测策略
 def backtest(df, initial_capital=100000):
     df['Position'] = 0
-    df['Cash'] = initial_capital
-    df['Holdings'] = 0
-    df['Portfolio'] = initial_capital
+    df['Cash'] = float(initial_capital)
+    df['Holdings'] = 0.0
+    df['Portfolio'] = float(initial_capital)
     
     position = 0
     cash = initial_capital


### PR DESCRIPTION
fix dtype warning about:
FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '55.54' has dtype incompatible with int64, please explicitly cast to a compatible dtype first.